### PR TITLE
Download By Volume & Merge Chapters by Volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Because your query should be more than 5 characters to avoid errors.
 
 - [X] Use `pterm` output instead `fmt`.
 - [X] Refactor `cmd` package.
-- [ ] Add rate limiter for client api.
+- [X] Add rate limiter for client api.
 - [ ] Create a Github action to automate the creation of `.deb` `.rpm` `.pkg.tar.zst` packages when a new release is created.
 - [ ] Add tests for `mangadexapi` package.
 - [ ] Refactor `internal/mdx` package.

--- a/cmd/find.go
+++ b/cmd/find.go
@@ -15,7 +15,7 @@ var (
 	}
 	title            string
 	isDoujinshiAllow bool
-	outputFile       bool
+	outputToFile     bool
 )
 
 func init() {
@@ -25,12 +25,12 @@ func init() {
 		"title", "t", "", "specifies the title of the manga to search for")
 	findCmd.Flags().BoolVarP(&isDoujinshiAllow,
 		"doujinshi", "d", false, "show doujinshi in list")
-	findCmd.Flags().BoolVarP(&outputFile,
-		"outputFile", "o", false, "Save the output to `output.json`")
+	findCmd.Flags().BoolVarP(&outputToFile,
+		"outputToFile", "o", false, "Save the search results to a json file.")
 
 	findCmd.MarkFlagRequired("title")
 }
 
 func find(cmd *cobra.Command, args []string) {
-	mdx.NewFindParams(title, isDoujinshiAllow, outputFile).Find()
+	mdx.NewFindParams(title, isDoujinshiAllow, outputToFile).Find()
 }

--- a/cmd/find.go
+++ b/cmd/find.go
@@ -15,6 +15,7 @@ var (
 	}
 	title            string
 	isDoujinshiAllow bool
+	outputFile       bool
 )
 
 func init() {
@@ -24,10 +25,12 @@ func init() {
 		"title", "t", "", "specifies the title of the manga to search for")
 	findCmd.Flags().BoolVarP(&isDoujinshiAllow,
 		"doujinshi", "d", false, "show doujinshi in list")
+	findCmd.Flags().BoolVarP(&outputFile,
+		"outputFile", "o", false, "Save the output to `output.json`")
 
 	findCmd.MarkFlagRequired("title")
 }
 
 func find(cmd *cobra.Command, args []string) {
-	mdx.NewFindParams(title, isDoujinshiAllow).Find()
+	mdx.NewFindParams(title, isDoujinshiAllow, outputFile).Find()
 }

--- a/internal/mdx/find.go
+++ b/internal/mdx/find.go
@@ -1,6 +1,8 @@
 package mdx
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 
 	"github.com/pterm/pterm"
@@ -11,14 +13,16 @@ type findParams struct {
 	isDoujinshiAllow bool
 	printedCount     int
 	offset           int
+	outputFile       bool
 }
 
-func NewFindParams(title string, isDoujinshiAllow bool) findParams {
+func NewFindParams(title string, isDoujinshiAllow bool, outputFile bool) findParams {
 	return findParams{
 		title:            title,
 		isDoujinshiAllow: isDoujinshiAllow,
 		printedCount:     25,
 		offset:           0,
+		outputFile:       outputFile,
 	}
 }
 
@@ -36,6 +40,41 @@ func (p findParams) Find() {
 		os.Exit(0)
 	}
 	spinner.Success("Manga found!")
+
+	// If output file is specified, fetch all results and save to JSON
+	if p.outputFile {
+		// If there are more results, fetch them all
+		allResults := response
+		currentOffset := p.printedCount
+
+		for currentOffset < response.Total {
+			spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Fetching more results (%d/%d)...", currentOffset, response.Total))
+			moreResults, err := client.Find(p.title, p.printedCount, currentOffset, p.isDoujinshiAllow)
+			if err != nil {
+				spinner.Fail("Failed to fetch additional results")
+				e.Printf("error while fetching additional results: %v\n", err)
+				os.Exit(1)
+			}
+			allResults.Data = append(allResults.Data, moreResults.Data...)
+			currentOffset += p.printedCount
+		}
+
+		jsonData, err := json.MarshalIndent(allResults.Data, "", "    ")
+		if err != nil {
+			e.Printf("error while marshaling JSON: %v\n", err)
+			os.Exit(1)
+		}
+
+		err = os.WriteFile("output.json", jsonData, 0644)
+		if err != nil {
+			e.Printf("error while writing JSON file: %v\n", err)
+			os.Exit(1)
+		}
+
+		spinner.Success(fmt.Sprintf("All %d results saved to output.json", response.Total))
+		// Don't output to console since it was saved to "output.json"
+		return
+	}
 
 	for _, m := range response.List() {
 		dp.Println("------------------------------")

--- a/internal/mdx/find.go
+++ b/internal/mdx/find.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/pterm/pterm"
 )
@@ -13,16 +14,16 @@ type findParams struct {
 	isDoujinshiAllow bool
 	printedCount     int
 	offset           int
-	outputFile       bool
+	outputToFile     bool
 }
 
-func NewFindParams(title string, isDoujinshiAllow bool, outputFile bool) findParams {
+func NewFindParams(title string, isDoujinshiAllow bool, outputToFile bool) findParams {
 	return findParams{
 		title:            title,
 		isDoujinshiAllow: isDoujinshiAllow,
 		printedCount:     25,
 		offset:           0,
-		outputFile:       outputFile,
+		outputToFile:     outputToFile,
 	}
 }
 
@@ -42,7 +43,7 @@ func (p findParams) Find() {
 	spinner.Success("Manga found!")
 
 	// If output file is specified, fetch all results and save to JSON
-	if p.outputFile {
+	if p.outputToFile {
 		// If there are more results, fetch them all
 		allResults := response
 		currentOffset := p.printedCount
@@ -64,15 +65,17 @@ func (p findParams) Find() {
 			e.Printf("error while marshaling JSON: %v\n", err)
 			os.Exit(1)
 		}
+		timeStamp := time.Now().Format("20060102")
+		fileName := fmt.Sprintf("Search-Results_%s.json", timeStamp)
 
-		err = os.WriteFile("output.json", jsonData, 0644)
+		err = os.WriteFile(fileName, jsonData, 0644)
 		if err != nil {
 			e.Printf("error while writing JSON file: %v\n", err)
 			os.Exit(1)
 		}
 
-		spinner.Success(fmt.Sprintf("All %d results saved to output.json", response.Total))
-		// Don't output to console since it was saved to "output.json"
+		spinner.Success("All %d results saved to %s", response.Total, fileName)
+
 		return
 	}
 

--- a/mangadexapi/api.go
+++ b/mangadexapi/api.go
@@ -117,10 +117,13 @@ func NewClient(userAgent string) Clientapi {
 
 	c := resty.New().
 		SetRetryCount(5).
-		SetRetryWaitTime(time.Second*2).
+		SetRetryWaitTime(time.Second*10).
 		SetLogger(silentLogger{}).
 		SetBaseURL(base_url).
-		SetHeader("User-Agent", userAgent)
+		SetHeader("User-Agent", userAgent).
+		AddRetryCondition(func(r *resty.Response, err error) bool {
+			return r.StatusCode() == 429
+		})
 
 	return Clientapi{
 		c: c,


### PR DESCRIPTION
## Description
This pull requests adds the option for the download command to download chapters for the provided volume or volume range. I have also added the option of being able to merge the chapters in the provided volume into the desired output. This is done by leveraging the same logic as the download chapters and merge commands that already existed. It adds new logic to build a map for the volumes and the chapters in each of those volumes. This map is used when merging the files and determining which chapters to download for the volume.

#### Please merge the following branches first as this branch contains code from those branches:

- [Fix rate limits](https://github.com/arimatakao/mdx/pull/5)
- [Add search output to .json](https://github.com/arimatakao/mdx/pull/6)